### PR TITLE
Enhance PAT handling in OnWorkItemUpdated function and update README …

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ This is an Azure Function that automatically updates Azure DevOps work items bas
    - In the **URL** field, enter the URL of your Azure Function.
    - In the **HTTP Headers** section, add the following headers:
      - `X-ADO-PAT`: Your Azure DevOps Personal Access Token (PAT) with sufficient permissions to read and update work items.
+
+      > Alternatively, you can set the PAT as an environment variable in your Azure Function and reference it in the header as `X-ADO-PAT: {your_pat_variable}` (do not forget the curly braces).
+
      - `X-ADO-RULES`: The URL to your DSL rules file in Azure DevOps. You can get this URL by navigating to the file in Azure DevOps, clicking on the "Download" button, and copying the URL from the browser's download list.
    - Then click **Finish** to create the subscription.
  


### PR DESCRIPTION
…with environment variable usage

You can now reference an environment variable in the X-ADO-PAT header option. This prevent you from exposing the PAT in Azure DevOps.